### PR TITLE
Set default values for entrypoint.sh if not run through github actions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,9 +12,9 @@ fi
 # shellcheck disable=SC2086
 reviewdog \
     -efm='%f:%l:%c:%*[0-9]:%*[0-9]:%t%n:%m' \
-    -name="${INPUT_TOOL_NAME}" \
-    -reporter="${INPUT_REPORTER}" \
-    -filter-mode="${INPUT_FILTER_MODE}" \
-    -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
-    -level="${INPUT_LEVEL}" \
+    -name="${INPUT_TOOL_NAME:-cfn-lint}" \
+    -reporter="${INPUT_REPORTER:-github-pr-check}" \
+    -filter-mode="${INPUT_FILTER_MODE:-added}" \
+    -fail-on-error="${INPUT_FAIL_ON_ERROR:-0}" \
+    -level="${INPUT_LEVEL:-error}" \
     ${INPUT_REVIEWDOG_FLAGS} < /tmp/out.log


### PR DESCRIPTION
- [x] set default values for environment variables in entrypoint.sh

<details><summary>Scenario</summary>
<p>
If someone changes their github action `uses` statement to be `docker://shogo82148/actions-cfn-lint:1.6.15-beta2` then the image used is pulled directly from docker hub and isn't passed any environment variables.  This means they are all empty strings and you get an error like this:

```bash
Run docker://shogo82148/actions-cfn-lint:1.6.15-beta2
  with:
    github_token: ***
    cfn_lint_args: --config-file .cfnlintrc
...
2021-02-22 02:55:01,812 - cfnlint.decode - ERROR - Template file not found: None
invalid boolean value "" for -fail-on-error: parse error
Usage:	reviewdog [flags]
```
</p>
</details>