### PR TITLE
make easier to test unreleased actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Show Version
-        run: |
-          echo "VERSION=$(cat VERSION)" >> "$GITHUB_ENV"
-      - name: Build the Docker image
-        run: docker build -t ghcr.io/${{ github.repository }}:"$VERSION" .
 
       - name: minimum example
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ branding:
   color: "orange"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/shogo82148/actions-cfn-lint:1.8.1"
+  image: "Dockerfile"
   args:
     - "**/*.yaml"
     - "**/*.yml"

--- a/prepare.sh
+++ b/prepare.sh
@@ -10,13 +10,29 @@ VERSION=$1
 MAJOR=$(echo "$VERSION" | cut -d. -f1)
 MINOR=$(echo "$VERSION" | cut -d. -f2)
 PATCH=$(echo "$VERSION" | cut -d. -f3)
+WORKING=$CURRENT/.working
 
-cd "$CURRENT"
+: clone
+ORIGIN=$(git remote get-url origin)
+rm -rf "$WORKING"
+git clone "$ORIGIN" "$WORKING"
+cd "$WORKING"
+
+: checkout releases branch
+git checkout -b "releases/v$MAJOR" "origin/releases/v$MAJOR" || git checkout -b "releases/v$MAJOR" main
+git merge -X theirs --no-ff -m "Merge branch 'main' into releases/v$MAJOR" main || true
+
+: configure to use the pre-built image
 echo "$VERSION" > VERSION
-perl -i -pe "s(docker://ghcr[.]io/shogo82148/actions-cfn-lint:[-a-zA-Z0-9.]*)(docker://ghcr.io/shogo82148/actions-cfn-lint:$VERSION)" action.yml
+git checkout main -- action.yml
+perl -i -pe "s(image:\\s*\"Dockerfile\")(image: \"docker://ghcr.io/shogo82148/actions-cfn-lint:$VERSION\")" action.yml
 git add VERSION action.yml
 git commit -m "bump v$MAJOR.$MINOR.$PATCH"
-git push origin main
 
+: publish to GitHub
 git tag -a "v$MAJOR.$MINOR.$PATCH" -m "release v$MAJOR.$MINOR.$PATCH"
 git push origin "v$MAJOR.$MINOR.$PATCH"
+
+: clean up
+cd "$CURRENT"
+rm -rf "$WORKING"

--- a/release.sh
+++ b/release.sh
@@ -20,8 +20,13 @@ VERSION=$1
 MAJOR=$(echo "$VERSION" | cut -d. -f1)
 MINOR=$(echo "$VERSION" | cut -d. -f2)
 PATCH=$(echo "$VERSION" | cut -d. -f3)
+WORKING=$CURRENT/.working
 
-cd "$CURRENT"
+: clone
+ORIGIN=$(git remote get-url origin)
+rm -rf "$WORKING"
+git clone "$ORIGIN" "$WORKING"
+cd "$WORKING"
 
 : release the action
 git checkout "v$MAJOR.$MINOR.$PATCH" || (
@@ -32,3 +37,6 @@ git checkout "v$MAJOR.$MINOR.$PATCH" || (
 )
 git tag -fa "v$MAJOR" -m "release v$MAJOR.$MINOR.$PATCH"
 git push -f origin "v$MAJOR"
+
+cd "$CURRENT"
+rm -rf "$WORKING"


### PR DESCRIPTION
currently, `uses: shogo82148/actions-cfn-lint@some-branch` uses the fixed version of the pre-built image.
it makes hard to test new features.

So I updated that `uses: shogo82148/actions-cfn-lint@some-branch` always builds a new image from Dockerfile.
`uses: shogo82148/actions-cfn-lint@v*.*.*` still uses the fixed version of the pre-built image.
