### PR TITLE
the build workflow ignores all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build Docker Image
 on:
   push:
     branches-ignore:
-      - '*'
+      - '**'
     tags:
       - 'v*.*.*'
   workflow_dispatch:


### PR DESCRIPTION
The wildcard `*` doesn't match path seperaters `/`.
We should use `**` instead of it.