### PR TITLE
fix --fail-on-error option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,3 +18,6 @@ reviewdog \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     ${INPUT_REVIEWDOG_FLAGS} < /tmp/out.log
+exit_code=$?
+
+exit $exit_code


### PR DESCRIPTION
entrypoint.sh doesn't check the exit code.
So the --fail-on-error option is not working.