### PR TITLE
use cfn_lint_args instead of args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: minimum example
-        uses: ./
-
-      - name: with args
+      - name: example
         uses: ./
         with:
           tool_name: cfn-lint with args
-          args: testdata/template.yaml
+          cfn_lint_args: testdata/template.yaml

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ Optional. Filtering mode for the reviewdog command \[`added`,`diff_context`,`fil
 
 ### `fail_on_error`
 
-Optional. Exit code for reviewdog when errors are found \[`true`,`false`\] Default is `false`.
+Optional. Exit code for reviewdog when errors are found \[`true`,`false`\]. Default is `false`.
 
 ### `reviewdog_flags`
 
 Optional. Additional reviewdog flags
 
-### `args`
+### `cfn_lint_args`
 
 Overrides the arguments for cfn-lint.
 The default value is `**/*.yaml **/*.yml **/*.json`.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "actions-cfn-lint"
 description: "cfn-lint with reviewdog"
-author: "Ichinose Shogo"
+author: "ICHINOSE Shogo"
 inputs:
   github_token:
     description: "set secrets.GITHUB_TOKEN or github.token"
@@ -31,8 +31,12 @@ inputs:
     description: "Additional reviewdog flags"
     default: ""
   cfn_lint_args:
-    description: override args for cfn-lint
+    description: "override args for cfn-lint"
     default: ""
+  args:
+    description: "args for cfn-lint"
+    default: ""
+    deprecationMessage: "use cfn_lint_args instead"
 outputs: {}
 branding:
   icon: "check-circle"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,10 @@ shopt -s globstar nullglob
 
 export REVIEWDOG_GITHUB_API_TOKEN=$INPUT_GITHUB_TOKEN
 
-if [ -n "$INPUT_ARGS" ]; then
+if [ -n "$INPUT_CFN_LINT_ARGS" ]; then
+    # shellcheck disable=SC2086
+    cfn-lint --format parseable $INPUT_CFN_LINT_ARGS > /tmp/out.log
+elif [ -n "$INPUT_ARGS" ]; then
     # shellcheck disable=SC2086
     cfn-lint --format parseable $INPUT_ARGS > /tmp/out.log
 else


### PR DESCRIPTION
`args` input is now deprecated.
use `cfn_lint_args` input instead.
