### PR TITLE
bump reviewdog v0.17.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY requirements.txt /requirements.txt
 RUN apk --no-cache add git bash && pip install --upgrade pip && pip install --no-cache -r /requirements.txt
 
 # install reviewdog
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ v0.16.0
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ v0.17.4
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Please version bump reviewdog v0.7.14 because it resolves the issue with [diff too large](https://github.com/reviewdog/reviewdog/issues/1696).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `reviewdog` to version `v0.17.4` to enhance tool performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->