### PR TITLE
bump python:3.13.1-alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.1-alpine3.20
+FROM python:3.13.1-alpine3.21
 
 # install cfn-lint
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated base Docker image to the latest Alpine Linux version for Python 3.13.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->