### PR TITLE
Change default value of 'level' to empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Optional. Tool name to use for reviewdog reporter. Useful when running multiple 
 
 ### `level`
 
-Optional. Report level for reviewdog \[`info`, `warning`, `error`\].
+Optional. Report level for reviewdog \[`info`, `warning`, `error`\]. Default is "".
 It's same as `-level` flag of reviewdog.
 
 ### `reporter`

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,8 @@ inputs:
     default: "${{ github.token }}"
   level:
     description: "Report level for reviewdog [info,warning,error]"
-    required: true
-    default: "error"
+    required: false
+    default: ""
   tool_name:
     description: "Tool name to use for reviewdog reporter"
     required: true


### PR DESCRIPTION
When 'level' is empty, reviewdog automatically determines whether it should be 'failure' or 'neutral' based on the check result.

https://github.com/reviewdog/reviewdog/blob/master/service/github/check.go#L282-L304

I propose this behavior as default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated GitHub Action documentation to clarify input parameter defaults.
	- The "level" parameter is now optional with an empty-string default.
	- The "cfn_lint_args" default is explicitly set to an empty string with guidance for previous behavior.
	- The "fail_on_error" input has been removed in favor of "fail_level," which now defaults to "none."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->