### PR TITLE
pin Docker base image to python:3.13.14-alpine3.24 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.7-alpine3.21
+FROM python:3.13.14-alpine3.24@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0
 
 # install cfn-lint
 COPY requirements.txt /requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: requirements
 requirements:
-	docker run --rm -v ${PWD}:/actions-cfn-lint --entrypoint '' python:3.13.3-alpine3.21 \
+	docker run --rm -v ${PWD}:/actions-cfn-lint --entrypoint '' python:3.13.14-alpine3.24@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0 \
 		sh -c 'pip install cfn-lint && pip freeze > /actions-cfn-lint/requirements.txt'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container runtime image to a newer Python 3.13 and Alpine Linux release.
  * Pinned the container image to a specific digest for improved build consistency and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->