### PR TITLE
bump Python 3.14.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.14-alpine3.24@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0
+FROM python:3.14.6-alpine3.24@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
 # install cfn-lint
 COPY requirements.txt /requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .PHONY: requirements
 requirements:
-	docker run --rm -v ${PWD}:/actions-cfn-lint --entrypoint '' python:3.13.14-alpine3.24@sha256:399babc8b49529dabfd9c922f2b5eea81d611e4512e3ed250d75bd2e7683f4b0 \
+	docker run --rm -v ${PWD}:/actions-cfn-lint --entrypoint '' python:3.14.6-alpine3.24@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92 \
 		sh -c 'pip install cfn-lint && pip freeze > /actions-cfn-lint/requirements.txt'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 annotated-types==0.7.0
 attrs==26.1.0
 aws-sam-translator==1.111.0
-boto3==1.43.46
-botocore==1.43.46
+boto3==1.43.51
+botocore==1.43.51
 cfn-lint==1.53.0
 jmespath==1.1.0
 jsonpatch==1.33


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container runtime to Python 3.14.6.
  * Refreshed the containerized tooling environment.
  * Updated AWS SDK dependencies (`boto3` and `botocore`) to version 1.43.51.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->